### PR TITLE
Fix EventsBundle display.

### DIFF
--- a/src/Etu/Module/EventsBundle/Resources/views/Memberships/events.html.twig
+++ b/src/Etu/Module/EventsBundle/Resources/views/Memberships/events.html.twig
@@ -7,11 +7,11 @@
 {% endblock %}
 
 {% block stylesheets %}
-    <link href="{{ asset('vendor/fullcalendar/fullcalendar.css') }}" rel="stylesheet" />
+    <link href="{{ asset('vendor/fullcalendar/dist/fullcalendar.min.css') }}" rel="stylesheet" />
 {% endblock %}
 
 {% block javascripts %}
-    <script src="{{ asset('vendor/fullcalendar/fullcalendar.min.js') }}" type="text/javascript"></script>
+    <script src="{{ asset('vendor/fullcalendar/dist/fullcalendar.min.js') }}" type="text/javascript"></script>
 	<script type="text/javascript">
 		var source = '{{ path('memberships_orga_events_find', {'login': orga.login}) }}',
 			createUrl = '{{ path('memberships_orga_events_create', {'login': orga.login}) }}',


### PR DESCRIPTION
Users were not able to create new events since the path to fullcalendar was not valid.

cf. https://github.com/ungdev/site-etu/blob/157fbb89119d48d7beba5c5f9be87ca787daa4c7/src/Etu/Module/EventsBundle/Resources/views/Main/index.html.twig#L24.